### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function parseSensors(lines, opts) {
     if ( matchAdapter  ) {
       result[currentDevice].adapter = matchAdapter[1];
     } else {
-      const matchSensor = line.match(/^(^[a-zA-Z0-9_ ]+):$/);
+      const matchSensor = line.match(/^(^[a-z0-9_\s]+):$/i);
       if ( matchSensor ) {
         currentSensor = matchSensor[1];
         result[currentDevice].sensors[currentSensor] = {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function parseSensors(lines, opts) {
     if ( matchAdapter  ) {
       result[currentDevice].adapter = matchAdapter[1];
     } else {
-      const matchSensor = line.match(/^(\w+):$/);
+      const matchSensor = line.match(/^(^[a-zA-Z0-9_ ]+):$/);
       if ( matchSensor ) {
         currentSensor = matchSensor[1];
         result[currentDevice].sensors[currentSensor] = {


### PR DESCRIPTION
Problem: some sensor labels have spaces in the name. The current regex does not select lines containing spaces in the label.

Example lm-sensors output:
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +34.0°C  (high = +84.0°C, crit = +100.0°C)
Core 0:        +31.0°C  (high = +84.0°C, crit = +100.0°C)
Core 1:        +32.0°C  (high = +84.0°C, crit = +100.0°C)
Core 2:        +29.0°C  (high = +84.0°C, crit = +100.0°C)
Core 3:        +29.0°C  (high = +84.0°C, crit = +100.0°C)

Current index.js renders a empty array for this adapter. Change does select these values.
Please improve the regex, this is outside my comfort zone but it works :)